### PR TITLE
Features/test deterministic guide return

### DIFF
--- a/tests/infer/test_predictive.py
+++ b/tests/infer/test_predictive.py
@@ -319,14 +319,14 @@ def test_deterministic_guide_return(
     )()
 
     if return_deterministic_guide_sites and use_determinisitic_guide:
+        assert "x4" in actual
+        assert_close(actual["x4"].mean(), y, rtol=0.1)
         # When return_sites is empty, include all deterministic guide sites
         if len(return_sites) == 0:
             assert "x5" in actual
             assert_close(actual["x5"].mean(), y, rtol=0.1)
         else:
             assert "x5" not in actual
-        assert "x4" in actual
-        assert_close(actual["x4"].mean(), y, rtol=0.1)
     else:
         assert "x4" not in actual
         assert "x5" not in actual

--- a/tests/infer/test_predictive.py
+++ b/tests/infer/test_predictive.py
@@ -272,8 +272,14 @@ def test_deterministic(with_plate, event_shape, predictive):
 @pytest.mark.parametrize("with_plate", [True, False])
 @pytest.mark.parametrize("event_shape", [(), (2,)])
 @pytest.mark.parametrize("return_deterministic_guide_sites", [True, False])
+@pytest.mark.parametrize("return_sites", [[], ["x4"]])
+@pytest.mark.parametrize("use_determinisitic_guide", [True, False])
 def test_deterministic_guide_return(
-    with_plate, event_shape, return_deterministic_guide_sites
+    with_plate,
+    event_shape,
+    return_deterministic_guide_sites,
+    return_sites,
+    use_determinisitic_guide,
 ):
     def model(y=None):
         with pyro.util.optional(pyro.plate("plate", 3), with_plate):
@@ -283,11 +289,21 @@ def test_deterministic_guide_return(
         pyro.deterministic("x3", x2)
         return pyro.sample("obs", dist.Normal(x2, 0.1).to_event(), obs=y)
 
-    def guide(y=None):
+    def determinisitic_guide(y=None):
         with pyro.util.optional(pyro.plate("plate", 3), with_plate):
-            x = pyro.sample("x", dist.Normal(0, 1).expand(event_shape).to_event())
+            x = pyro.sample("x", dist.Normal(0, 2).expand(event_shape).to_event())
+            x4 = pyro.deterministic("x4", x**2, event_dim=len(event_shape))
 
-        pyro.deterministic("x4", x)
+        pyro.deterministic("x5", x4)
+
+    def non_determinisitic_guide(y=None):
+        with pyro.util.optional(pyro.plate("plate", 3), with_plate):
+            pyro.sample("x", dist.Normal(0, 2).expand(event_shape).to_event())
+
+    if use_determinisitic_guide:
+        guide = determinisitic_guide
+    else:
+        guide = non_determinisitic_guide
 
     y = torch.tensor(4.0)
     svi = SVI(model, guide, optim.Adam(dict(lr=0.1)), Trace_ELBO())
@@ -298,13 +314,22 @@ def test_deterministic_guide_return(
         model,
         guide=guide,
         num_samples=1000,
+        return_sites=return_sites,
         return_deterministic_guide_sites=return_deterministic_guide_sites,
     )()
 
-    if return_deterministic_guide_sites:
+    if return_deterministic_guide_sites and use_determinisitic_guide:
+        # When return_sites is empty, include all deterministic guide sites
+        if len(return_sites) == 0:
+            assert "x5" in actual
+            assert_close(actual["x5"].mean(), y, rtol=0.1)
+        else:
+            assert "x5" not in actual
         assert "x4" in actual
+        assert_close(actual["x4"].mean(), y, rtol=0.1)
     else:
         assert "x4" not in actual
+        assert "x5" not in actual
 
 
 def test_get_mask_optimization():


### PR DESCRIPTION
Increased coverage based on specification provided in [issue #3358](https://github.com/pyro-ppl/pyro/issues/3358#issuecomment-2073035466)

Proposed Changes:

- Added 2 new parameters `return_sites` and `use_determinisitic_guide` with 2 values each
- Added assertions to check behavior when `return_deterministic` is <ins>true</ins>
  - When `return_sites` is empty, assert all deterministic guide sites are returned
  - When `return_sites` contains only 1 of 2 deterministic guide sites, assert that correct site is returned
  - When there are no deterministic guide sites, assert behavior is the same as when `return_deterministic` is <ins>false</ins>
- Added assertion to check that no deterministic sites are returned when `return_deterministic`  is <ins>false</ins> and there are deterministic sites in the guide
- Added checks to verify correct values of deterministic guide sites "w4" and "w5" when returned depending on behavior specified above

Notes:

- All (32) test cases pass locally
  - Unsure if including `with_plate` and `event_shape` parameters is necessary, kept them in for now
- Assumed expected values of deterministic guide sites was to match Y
- Was unable to fully pass mypy tests when running "make test" due to non-utf encoding present in PyTorch ([PyTorch issue #124897](https://github.com/pytorch/pytorch/issues/124897 ))
  - "make format", "make lint", and running pytest on `test_predictive.py` all succeeded